### PR TITLE
Add conteudo de texto aos arquivos criados.

### DIFF
--- a/scripts/cria_pasta.py
+++ b/scripts/cria_pasta.py
@@ -8,16 +8,46 @@ parser.add_argument("caminho_pasta")
 args = parser.parse_args()
 # print(args.nome_arquivo, args.caminho_pasta)
 
+conteudo_teste = """from metro_milimetro.main import resposta
+import inspect
+import pytest
+
+
+def test_not_none():
+    assert resposta(10) is not None, "Esperado valor diferente de 'None'"
+
+
+def test_type():
+    assert type(resposta(13)) == int or type(resposta(3.2)) == float, "Esperado um inteiro ou float"
+
+
+def test_parameters():
+    assert len(inspect.getfullargspec(resposta).args) == 1, "Assinatura da função deverá receber um parâmetro"
+
+
+def test_options_resposta():
+    assert resposta(10) == 10000, f"Esperado valor 10000"
+    assert resposta(1.2) == 1200, f"Esperado valor 1200"
+    assert resposta(0.93) == 930, f"Esperado valor 930"
+"""
+
 caminho_pasta = Path(args.caminho_pasta)
 if not caminho_pasta.parent.is_dir(): 
     print(f'{caminho_pasta.parent} não é um caminho válido.')
 else:
     caminho_pasta.mkdir()
     (caminho_pasta / '_README.md').touch()
+    (caminho_pasta / '_README.md').write_text(
+    '## Objetivo\n'
+    '## Especificação'
+    )
     (caminho_pasta / 'main.py').touch()
+    (caminho_pasta / 'main.py').write_text(
+    'def resposta():\n' 
+    '    pass')
     (caminho_pasta / '__init__.py').touch()
     pasta_testes = caminho_pasta / 'tests'
     pasta_testes.mkdir()
     (pasta_testes/ '__init__.py').touch()
     (pasta_testes/ 'test_.py').touch()
-    
+    (pasta_testes/ 'test_.py').write_text(conteudo_teste, encoding="utf-8")


### PR DESCRIPTION
See #4.

@gabrielbdornas 

Essa atividade era mais um desafio pra mim do que uma grande necessidade. Queria testa se conseguia avançar com o script lendo a documentação das bibliotecas usadas e me treinar como dev. 

Diante disso, tentei incluir o conteúdo de texto dos arquivos criados pelo script, facilitando na hora de criar novos exercícios. Não me preocupei nesse momento com o conteúdo, apenas em fazer funcionar.